### PR TITLE
qualcommax: only disable swiotlb for platforms <= 512M

### DIFF
--- a/target/linux/qualcommax/patches-6.6/9991-arm64-dts-qcom-disable-swiotlb-for-64mb-savings.patch
+++ b/target/linux/qualcommax/patches-6.6/9991-arm64-dts-qcom-disable-swiotlb-for-64mb-savings.patch
@@ -42,17 +42,6 @@
  	};
  
  	keys {
---- a/arch/arm64/boot/dts/qcom/ipq8071-eap102.dts
-+++ b/arch/arm64/boot/dts/qcom/ipq8071-eap102.dts
-@@ -30,7 +30,7 @@
- 
- 	chosen {
- 		stdout-path = "serial0:115200n8";
--		bootargs-append = " root=/dev/ubiblock0_1";
-+		bootargs-append = " coherent_pool=2M swiotlb=noforce root=/dev/ubiblock0_1";
- 	};
- 
- 	keys {
 --- a/arch/arm64/boot/dts/qcom/ipq8071-mf269.dts
 +++ b/arch/arm64/boot/dts/qcom/ipq8071-mf269.dts
 @@ -24,7 +24,7 @@
@@ -64,17 +53,6 @@
  	};
  
  	keys {
---- a/arch/arm64/boot/dts/qcom/ipq8072-aw1000.dts
-+++ b/arch/arm64/boot/dts/qcom/ipq8072-aw1000.dts
-@@ -34,7 +34,7 @@
- 
- 	chosen {
- 		stdout-path = "serial0:115200n8";
--		bootargs-append = " root=/dev/ubiblock0_1";
-+		bootargs-append = " coherent_pool=2M swiotlb=noforce root=/dev/ubiblock0_1";
- 	};
- 
- 	gpio-export {
 --- a/arch/arm64/boot/dts/qcom/ipq8072-ax880.dts
 +++ b/arch/arm64/boot/dts/qcom/ipq8072-ax880.dts
 @@ -29,7 +29,7 @@
@@ -83,39 +61,6 @@
  		stdout-path = "serial0:115200n8";
 -		bootargs-append = " root=/dev/ubiblock0_1";
 +		bootargs-append = " coherent_pool=2M swiotlb=noforce root=/dev/ubiblock0_1";
- 	};
- 
- 	keys {
---- a/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
-+++ b/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
-@@ -26,7 +26,7 @@
- 
- 	chosen {
- 		stdout-path = "serial0:115200n8";
--		bootargs-append = " root=/dev/ubiblock0_0";
-+		bootargs-append = " coherent_pool=2M swiotlb=noforce root=/dev/ubiblock0_0";
- 	};
- 
- 	keys {
---- a/arch/arm64/boot/dts/qcom/ipq8072-dl-wrx36.dts
-+++ b/arch/arm64/boot/dts/qcom/ipq8072-dl-wrx36.dts
-@@ -32,7 +32,7 @@
- 
- 	chosen {
- 		stdout-path = "serial0:115200n8";
--		bootargs-append = " root=/dev/ubiblock0_1";
-+		bootargs-append = " coherent_pool=2M swiotlb=noforce root=/dev/ubiblock0_1";
- 	};
- 
- 	keys {
---- a/arch/arm64/boot/dts/qcom/ipq8072-mx5300.dts
-+++ b/arch/arm64/boot/dts/qcom/ipq8072-mx5300.dts
-@@ -32,7 +32,7 @@
- 
- 	chosen {
- 		stdout-path = "serial0:115200n8";
--		bootargs-append = " root=/dev/ubiblock0_0 rootfstype=squashfs ro";
-+		bootargs-append = " coherent_pool=2M swiotlb=noforce root=/dev/ubiblock0_0 rootfstype=squashfs ro";
  	};
  
  	keys {
@@ -130,17 +75,6 @@
  	};
  
  	keys {
---- a/arch/arm64/boot/dts/qcom/ipq8072-wax620.dts
-+++ b/arch/arm64/boot/dts/qcom/ipq8072-wax620.dts
-@@ -28,7 +28,7 @@
- 		 * Netgear's U-Boot adds "ubi.mtd=rootfs root=mtd:ubi_rootfs"
- 		 * That fails to create a UBI block device, so add it here.
- 		*/
--		bootargs-append = " root=/dev/ubiblock0_1";
-+		bootargs-append = " coherent_pool=2M swiotlb=noforce root=/dev/ubiblock0_1";
- 	};
- 
- 	keys {
 --- a/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
 +++ b/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
 @@ -31,7 +31,7 @@
@@ -152,39 +86,6 @@
  	};
  
  	keys {
---- a/arch/arm64/boot/dts/qcom/ipq8074-rax120v2.dts
-+++ b/arch/arm64/boot/dts/qcom/ipq8074-rax120v2.dts
-@@ -25,7 +25,7 @@
- 
- 	chosen {
- 		stdout-path = "serial0:115200n8";
--		bootargs-append = " ubi.mtd=rootfs root=/dev/ubiblock0_0";
-+		bootargs-append = " coherent_pool=2M swiotlb=noforce ubi.mtd=rootfs root=/dev/ubiblock0_0";
- 	};
- 
- 	keys {
---- a/arch/arm64/boot/dts/qcom/ipq8074-wax630.dts
-+++ b/arch/arm64/boot/dts/qcom/ipq8074-wax630.dts
-@@ -29,7 +29,7 @@
- 
- 	chosen {
- 		stdout-path = "serial0:115200n8";
--		bootargs-append = " root=/dev/ubiblock0_1";
-+		bootargs-append = " coherent_pool=2M swiotlb=noforce root=/dev/ubiblock0_1";
- 	};
- 
- 	keys {
---- a/arch/arm64/boot/dts/qcom/ipq8074-wxr-5950ax12.dts
-+++ b/arch/arm64/boot/dts/qcom/ipq8074-wxr-5950ax12.dts
-@@ -25,7 +25,7 @@
- 
- 	chosen {
- 		stdout-path = "serial0:115200n8";
--		bootargs-append = " ubi.mtd=user_property root=/dev/ubiblock1_0";
-+		bootargs-append = " coherent_pool=2M swiotlb=noforce ubi.mtd=user_property root=/dev/ubiblock1_0";
- 	};
- 
- 	leds {
 --- a/arch/arm64/boot/dts/qcom/ipq8174-mx4200.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq8174-mx4200.dtsi
 @@ -29,7 +29,7 @@


### PR DESCRIPTION
Disabling swiotlb is only required for platforms with 512M or less to save 64mb.