### PR TITLE
openssl: conditionally disable engine section

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_VERSION:=3.0.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_BUILD_PARALLEL:=1
@@ -416,6 +416,8 @@ define Package/libopenssl-conf/install
 	$(INSTALL_BIN) ./files/openssl.init $(1)/etc/init.d/openssl
 	$(SED) 's!%ENGINES_DIR%!/usr/lib/$(ENGINES_DIR)!' $(1)/etc/init.d/openssl
 	touch $(1)/etc/config/openssl
+	$(if $(CONFIG_OPENSSL_ENGINE),,
+		$(SED) 's!engines = engines_sect!#&!' $(1)/etc/ssl/openssl.cnf)
 	$(if $(CONFIG_OPENSSL_ENGINE_BUILTIN_DEVCRYPTO),
 		$(CP) ./files/devcrypto.cnf $(1)/etc/ssl/modules.cnf.d/
 		echo -e "config engine 'devcrypto'\n\toption enabled '1'\n\toption builtin '1'" >> $(1)/etc/config/openssl)


### PR DESCRIPTION
Currently, the build option to enable/disable engine support isn't reflected in the final '/etc/ssl/openssl.cnf' config. It assumes `engines` is always enabled, producing an error whenever running any commands in openssl util or programs that explicitly use settings from '/etc/ssl/openssl.cnf'.

```
➤ openssl version
FATAL: Startup failure (dev note: apps_startup()) for openssl
307D1EA97F000000:error:12800067:lib(37):dlfcn_load:reason(103):crypto/dso/dso_dlfcn.c:118:filename(libengines.so):
Error loading shared library libengines.so: No such file or directory
307D1EA97F000000:error:12800067:lib(37):DSO_load:reason(103):crypto/dso/dso_lib.c:152:
307D1EA97F000000:error:0700006E:lib(14):module_load_dso:reason(110):crypto/conf/conf_mod.c:321:module=engines, path=engines
307D1EA97F000000:error:07000071:lib(14):module_run:reason(113):crypto/conf/conf_mod.c:266:module=engines
```

Build should check for the `CONFIG_OPENSSL_ENGINE` option, and comment out `engines` if not explicitly enabled.

Example:
```
[openssl_init]
providers = provider_sect
```

After this change, openssl util works correctly.

```
➤ openssl version
OpenSSL 3.0.14 4 Jun 2024 (Library: OpenSSL 3.0.14 4 Jun 2024)
```

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the OpenSSL build process to conditionally disable the 'engines' section in the '/etc/ssl/openssl.cnf' configuration file if the 'CONFIG_OPENSSL_ENGINE' option is not enabled. This prevents errors related to missing engine libraries when running OpenSSL commands or programs that use the OpenSSL configuration.

* **Enhancements**:
    - Conditionally disable the 'engines' section in the OpenSSL configuration file based on the 'CONFIG_OPENSSL_ENGINE' build option.

<!-- Generated by sourcery-ai[bot]: end summary -->